### PR TITLE
Add HTTP runtime sample

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,14 @@
+# HTTP runtime sample
+
+```bash
+# start host
+python samples/run_server.py
+# in two extra shells
+python samples/workers/reverse_agent.py
+python samples/workers/upper_agent.py
+# exercise the agents
+python samples/orchestrator.py
+```
+
+Works on Python 3.10+.  No gRPC, no Protobufs, just FastAPI + HTTPX + WebSockets.  Happy hacking!
+

--- a/samples/orchestrator.py
+++ b/samples/orchestrator.py
@@ -1,0 +1,27 @@
+import asyncio
+import logging
+
+from autogen_core import AgentId
+
+from autogen_http_runtime.runtimes.http import HttpWorkerAgentRuntime
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    rt = HttpWorkerAgentRuntime("http://127.0.0.1:9000")
+    await rt.start()
+
+    reverse = AgentId("reverse", "default")
+    upper = AgentId("upper", "default")
+
+    txt = "Hello distributed HTTP runtime!"
+    out1 = await rt.send_message(txt, reverse)
+    out2 = await rt.send_message(txt, upper)
+    print(f"{reverse.type} → {out1}")  # noqa: T201
+    print(f"{upper.type}   → {out2}")  # noqa: T201
+
+    await rt.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/run_server.py
+++ b/samples/run_server.py
@@ -1,0 +1,16 @@
+import asyncio
+import logging
+
+from autogen_http_runtime.runtimes.http import HttpAgentServer
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    server = HttpAgentServer(address="127.0.0.1", port=9000)
+    server.start()
+    print("\U0001f680  HTTP Agent Server running at http://127.0.0.1:9000  –  press Ctrl‑C to stop")  # noqa: T201
+    await server.stop_when_signal()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/workers/reverse_agent.py
+++ b/samples/workers/reverse_agent.py
@@ -1,0 +1,24 @@
+import asyncio
+import logging
+
+from autogen_core import BaseAgent, MessageContext
+
+from autogen_http_runtime.runtimes.http import HttpWorkerAgentRuntime
+
+
+class ReverseAgent(BaseAgent):
+    async def on_message(self, message: str, ctx: MessageContext):
+        return message[::-1]
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    rt = HttpWorkerAgentRuntime("http://127.0.0.1:9000")
+    await rt.register_factory("reverse", lambda: ReverseAgent())
+    await rt.start()
+    print("\U0001f527  ReverseAgent registered – waiting for messages…")  # noqa: T201
+    await rt.stop_when_signal()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/samples/workers/upper_agent.py
+++ b/samples/workers/upper_agent.py
@@ -1,0 +1,24 @@
+import asyncio
+import logging
+
+from autogen_core import BaseAgent, MessageContext
+
+from autogen_http_runtime.runtimes.http import HttpWorkerAgentRuntime
+
+
+class UpperAgent(BaseAgent):
+    async def on_message(self, message: str, ctx: MessageContext):
+        return message.upper()
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    rt = HttpWorkerAgentRuntime("http://127.0.0.1:9000")
+    await rt.register_factory("upper", lambda: UpperAgent())
+    await rt.start()
+    print("\U0001f527  UpperAgent registered – waiting for messages…")  # noqa: T201
+    await rt.stop_when_signal()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `samples/` folder showcasing the `HttpAgentServer` and `HttpWorkerAgentRuntime`
- include demo workers (`reverse` and `upper`), a server launcher and orchestrator
- update sample files to silence print warnings

## Testing
- `ruff format samples/run_server.py samples/orchestrator.py samples/workers/reverse_agent.py samples/workers/upper_agent.py`
- `ruff check samples/run_server.py samples/orchestrator.py samples/workers/reverse_agent.py samples/workers/upper_agent.py`
- `pyright samples/run_server.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684bfb8ec734832b9049c3ca4cfb97f8