### PR TITLE
Fix sample runtime string serialization

### DIFF
--- a/samples/orchestrator.py
+++ b/samples/orchestrator.py
@@ -4,11 +4,13 @@ import logging
 from autogen_core import AgentId
 
 from autogen_http_runtime.runtimes.http import HttpWorkerAgentRuntime
+from samples.string_serializer import StringMessageSerializer
 
 
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     rt = HttpWorkerAgentRuntime("http://127.0.0.1:9000")
+    rt.add_message_serializer(StringMessageSerializer())
     await rt.start()
 
     reverse = AgentId("reverse", "default")

--- a/samples/string_serializer.py
+++ b/samples/string_serializer.py
@@ -1,0 +1,18 @@
+from autogen_core._serialization import JSON_DATA_CONTENT_TYPE, MessageSerializer
+
+class StringMessageSerializer(MessageSerializer[str]):
+    """Serialize plain strings as UTF-8 JSON text."""
+
+    @property
+    def data_content_type(self) -> str:
+        return JSON_DATA_CONTENT_TYPE
+
+    @property
+    def type_name(self) -> str:
+        return "str"
+
+    def deserialize(self, payload: bytes) -> str:
+        return payload.decode("utf-8")
+
+    def serialize(self, message: str) -> bytes:
+        return message.encode("utf-8")

--- a/samples/workers/reverse_agent.py
+++ b/samples/workers/reverse_agent.py
@@ -4,6 +4,7 @@ import logging
 from autogen_core import BaseAgent, MessageContext
 
 from autogen_http_runtime.runtimes.http import HttpWorkerAgentRuntime
+from samples.string_serializer import StringMessageSerializer
 
 
 class ReverseAgent(BaseAgent):
@@ -14,6 +15,7 @@ class ReverseAgent(BaseAgent):
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     rt = HttpWorkerAgentRuntime("http://127.0.0.1:9000")
+    rt.add_message_serializer(StringMessageSerializer())
     await rt.register_factory("reverse", lambda: ReverseAgent())
     await rt.start()
     print("\U0001f527  ReverseAgent registered – waiting for messages…")  # noqa: T201

--- a/samples/workers/upper_agent.py
+++ b/samples/workers/upper_agent.py
@@ -4,6 +4,7 @@ import logging
 from autogen_core import BaseAgent, MessageContext
 
 from autogen_http_runtime.runtimes.http import HttpWorkerAgentRuntime
+from samples.string_serializer import StringMessageSerializer
 
 
 class UpperAgent(BaseAgent):
@@ -14,6 +15,7 @@ class UpperAgent(BaseAgent):
 async def main() -> None:
     logging.basicConfig(level=logging.INFO)
     rt = HttpWorkerAgentRuntime("http://127.0.0.1:9000")
+    rt.add_message_serializer(StringMessageSerializer())
     await rt.register_factory("upper", lambda: UpperAgent())
     await rt.start()
     print("\U0001f527  UpperAgent registered – waiting for messages…")  # noqa: T201


### PR DESCRIPTION
## Summary
- add `StringMessageSerializer` to handle raw strings
- register the serializer in orchestrator and worker runtimes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_684cb448c08c832b8ed5dc1eb6b8ff47