### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Build and publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install build tool
+        run: python -m pip install --upgrade build
+      - name: Build package
+        run: python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and publish package on tag push or manual dispatch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc66cd6d8832bb6199c1288ca86fa